### PR TITLE
Fix `unsupported maildriver Mandrill` warning when using fedeisas/lar…

### DIFF
--- a/src/MandrillServiceProvider.php
+++ b/src/MandrillServiceProvider.php
@@ -2,16 +2,20 @@
 
 namespace LaravelMandrill;
 
+use Illuminate\Mail\MailManager;
 use Illuminate\Support\ServiceProvider;
 
 class MandrillServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function register()
     {
-        $this->app['mail.manager']->extend('mandrill', function () {
-            $config = $this->app['config']->get('services.mandrill', []);
-
-            return new MandrillTransport(new \GuzzleHttp\Client($config), $config['secret']);
+        $this->app->resolving(MailManager::class, function (MailManager $manager) {
+            $manager->extend('mandrill', function () {
+                $config = $this->app['config']->get('services.mandrill', []);
+                return new \LaravelMandrill\MandrillTransport(
+                    new \GuzzleHttp\Client($config), $config['secret']
+                );
+            });
         });
     }
 }

--- a/src/MandrillServiceProvider.php
+++ b/src/MandrillServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace LaravelMandrill;
 
+use GuzzleHttp\Client;
 use Illuminate\Mail\MailManager;
 use Illuminate\Support\ServiceProvider;
+use LaravelMandrill\MandrillTransport;
 
 class MandrillServiceProvider extends ServiceProvider
 {
@@ -12,8 +14,8 @@ class MandrillServiceProvider extends ServiceProvider
         $this->app->resolving(MailManager::class, function (MailManager $manager) {
             $manager->extend('mandrill', function () {
                 $config = $this->app['config']->get('services.mandrill', []);
-                return new \LaravelMandrill\MandrillTransport(
-                    new \GuzzleHttp\Client($config), $config['secret']
+                return new MandrillTransport(
+                    new Client($config), $config['secret']
                 );
             });
         });


### PR DESCRIPTION
Fix `unsupported maildriver Mandrill` warning when using fedeisas/laravel-mail-css-inliner.

Since pull https://github.com/therobfonz/laravel-mandrill-driver/pull/6 got silent.