### PR TITLE
Remove unneeded use statement

### DIFF
--- a/src/MandrillServiceProvider.php
+++ b/src/MandrillServiceProvider.php
@@ -5,7 +5,6 @@ namespace LaravelMandrill;
 use GuzzleHttp\Client;
 use Illuminate\Mail\MailManager;
 use Illuminate\Support\ServiceProvider;
-use LaravelMandrill\MandrillTransport;
 
 class MandrillServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Sorry, I totally forgot MandrillTransport is in the same namespace so no use statement needed :-)
Thanks for merging!