### PR TITLE
Added generic X-Message-ID in mail transport

### DIFF
--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -42,7 +42,7 @@ class MandrillTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $this->client->request('POST', 'https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+        $response = $this->client->request('POST', 'https://mandrillapp.com/api/1.0/messages/send-raw.json', [
             'form_params' => [
                 'key' => $this->key,
                 'to' => $this->getTo($message),
@@ -50,6 +50,10 @@ class MandrillTransport extends Transport
                 'async' => true,
             ],
         ]);
+
+        $message->getHeaders()->addTextHeader(
+            'X-Message-ID', $this->getMessageId($response)
+        );
 
         $this->sendPerformed($message);
 

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -4,6 +4,8 @@ namespace LaravelMandrill;
 
 use GuzzleHttp\ClientInterface;
 use Illuminate\Mail\Transport\Transport;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ResponseInterface;
 use Swift_Mime_SimpleMessage;
 
 class MandrillTransport extends Transport
@@ -58,6 +60,21 @@ class MandrillTransport extends Transport
         $this->sendPerformed($message);
 
         return $this->numberOfRecipients($message);
+    }
+
+    /**
+     * Get the message ID from the response.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return string
+     * @throws \JsonException
+     */
+    protected function getMessageId(ResponseInterface $response)
+    {
+        $response = json_parse_strict((string) $response->getBody());
+
+        return Arr::get($response, '0._id');
     }
 
     /**


### PR DESCRIPTION
`X-Message-ID` contains the message id returned by Mandrill.

This PR adds the same functionality found in Laravel's Mailgun Transport.

"The X-Message-ID can be retrieved and used to keep track of upcoming triggered web-hook events from the same third-party."