### PR TITLE
composer support for version 8 php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "illuminate/support": "^8.0"
     },


### PR DESCRIPTION
the current composer.json only allows for php 7 versions from 7.4 onwards.
php 8 has recently been released, and it would be nice if php 8 was allowed also