### PR TITLE
Fix test expecting wrong Mandrill API version

### DIFF
--- a/tests/MandrillTransportTest.php
+++ b/tests/MandrillTransportTest.php
@@ -77,7 +77,7 @@ class MandrillTransportTest extends TestCase
 
         // Ensure data all got posted to expected locations
         $this->assertEquals($history[0]['request']->getMethod(), 'POST');
-        $this->assertEquals($history[0]['request']->getRequestTarget(), '/api/1.0/messages/send-raw');
+        $this->assertEquals($history[0]['request']->getRequestTarget(), '/api/1.3/messages/send-raw');
         $this->assertCount(1, $history);
     }
 


### PR DESCRIPTION
## Summary
- The `mailchimp/transactional` SDK now uses API version 1.3 (base URL `https://mandrillapp.com/api/1.3`), but the `testMessageIdIsReturned` test was asserting the request target as `/api/1.0/messages/send-raw`
- Updated the assertion to expect `/api/1.3/messages/send-raw`, which matches the current SDK behavior
- This was the sole cause of all CI failures across every PHP/Laravel matrix combination

## Test plan
- [x] All 3 tests pass locally with `vendor/bin/phpunit`
- [ ] CI should go green on all matrix jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)